### PR TITLE
Fix traceback in listing when no antibiotic class was set

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,4 +4,4 @@ Changelog
 1.0.0 (unreleased)
 ------------------
 
-- Initial Release
+- #2 Fix traceback in listing when no antibiotic class was set

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,3 +5,4 @@ Changelog
 ------------------
 
 - #2 Fix traceback in listing when no antibiotic class was set
+- Initial Release

--- a/src/senaite/abx/behaviors/antibiotic.py
+++ b/src/senaite/abx/behaviors/antibiotic.py
@@ -39,9 +39,8 @@ class IAntibioticBehavior(model.Schema):
 
     antibiotic_class = schema.Choice(
         title=_(u"Antibiotic class"),
-        vocabulary="senaite.abx.vocabularies.antibiotic_classes",
+        source="senaite.abx.vocabularies.antibiotic_classes",
         required=False,
-        missing_value=[],
     )
 
 
@@ -67,6 +66,6 @@ class Antibiotic(object):
     def _set_antibiotic_class(self, value):
         if api.is_uid(value) or api.is_dexterity_content(value):
             value = api.get_uid(value)
-            self.context.antibiotic = value
+            self.context.antibiotic_class = value
 
     antibiotic_class = property(_get_antibiotic_class, _set_antibiotic_class)

--- a/src/senaite/abx/browser/content/antibioticfolder.py
+++ b/src/senaite/abx/browser/content/antibioticfolder.py
@@ -134,6 +134,7 @@ class AntibioticFolderView(ListingView):
         if antibiotic_class:
             item["category"] = api.get_title(antibiotic_class)
             item["replace"]["category"] = get_link_for(antibiotic_class)
+        return item
 
     def get_children_hook(self, parent_uid, child_uids=None):
         """Hook to get the children of an item

--- a/src/senaite/abx/browser/content/antibioticfolder.py
+++ b/src/senaite/abx/browser/content/antibioticfolder.py
@@ -61,10 +61,10 @@ class AntibioticFolderView(ListingView):
                 "title": _c("Title"),
                 "index": "sortable_title"
             }),
-            ("Abbreviation", {
+            ("abbreviation", {
                 "title": _("Abbreviation"),
             }),
-            ("Category", {
+            ("category", {
                 "title": _("Class"),
             }),
             ("Description", {
@@ -129,10 +129,11 @@ class AntibioticFolderView(ListingView):
         obj = api.get_object(obj)
         antibiotic_class = obj.antibiotic_class
         item["replace"]["Title"] = get_link_for(obj)
-        item["replace"]["Category"] = get_link_for(antibiotic_class)
-        item["Abbreviation"] = obj.abbreviation
-        item["category"] = api.get_title(antibiotic_class)
-        return item
+        item["abbreviation"] = obj.abbreviation
+        item["category"] = _("Other")
+        if antibiotic_class:
+            item["category"] = api.get_title(antibiotic_class)
+            item["replace"]["category"] = get_link_for(antibiotic_class)
 
     def get_children_hook(self, parent_uid, child_uids=None):
         """Hook to get the children of an item

--- a/src/senaite/abx/vocabularies.py
+++ b/src/senaite/abx/vocabularies.py
@@ -40,11 +40,12 @@ class AntibioticClassesVocabulary(object):
             "sort_on": "sortable_title",
             "sort_order": "ascending",
         }
+        items = []
         brains = api.search(query, SETUP_CATALOG)
-        items = [
-            SimpleTerm(api.get_uid(brain), title=api.get_title(brain))
-            for brain in brains
-        ]
+        for brain in brains:
+            uid = api.get_uid(brain)
+            title = api.get_title(brain)
+            items.append(SimpleTerm(uid, uid, title))
 
         return SimpleVocabulary(items)
 


### PR DESCRIPTION
## Description

This PR fixes a traceback in the listing view when no Antibiotic class is set.

For traceback see ticket: #1