### PR TITLE
Fix default antibiotics are not created on install

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -14,7 +14,6 @@ parts =
     zopepy
     update_translations
     write_code_headers
-    update_sources
 
 eggs =
     senaite.core
@@ -98,12 +97,6 @@ mode = 755
 recipe = collective.recipe.template
 output = ${buildout:directory}/bin/write_code_headers
 input = ${buildout:directory}/templates/write_code_headers.py.in
-mode = 755
-
-[update_sources]
-recipe = collective.recipe.template
-output = ${buildout:directory}/bin/update_sources
-input = ${buildout:directory}/templates/update_sources.in
 mode = 755
 
 [versions]

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -42,13 +42,13 @@ sources = sources
 auto-checkout = *
 
 [sources]
-senaite.core = git git://github.com/senaite/senaite.core.git pushurl=git@github.com:senaite/senaite.core.git branch=2.x
-senaite.app.listing = git git://github.com/senaite/senaite.app.listing.git pushurl=git@github.com:senaite/senaite.app.listing.git branch=2.x
-senaite.app.spotlight = git git://github.com/senaite/senaite.app.spotlight.git pushurl=git@github.com:senaite/senaite.app.spotlight.git branch=2.x
-senaite.app.supermodel = git git://github.com/senaite/senaite.app.supermodel.git pushurl=git@github.com:senaite/senaite.app.supermodel.git branch=2.x
-senaite.impress = git git://github.com/senaite/senaite.impress.git pushurl=git@github.com:senaite/senaite.impress.git branch=2.x
-senaite.jsonapi = git git://github.com/senaite/senaite.jsonapi.git pushurl=git@github.com:senaite/senaite.jsonapi.git branch=2.x
-senaite.lims = git git://github.com/senaite/senaite.lims.git pushurl=git@github.com:senaite/senaite.lims.git branch=2.x
+senaite.core = git https://github.com/senaite/senaite.core.git pushurl=git@github.com:senaite/senaite.core.git branch=2.x
+senaite.app.listing = git https://github.com/senaite/senaite.app.listing.git pushurl=git@github.com:senaite/senaite.app.listing.git branch=2.x
+senaite.app.spotlight = git https://github.com/senaite/senaite.app.spotlight.git pushurl=git@github.com:senaite/senaite.app.spotlight.git branch=2.x
+senaite.app.supermodel = git https://github.com/senaite/senaite.app.supermodel.git pushurl=git@github.com:senaite/senaite.app.supermodel.git branch=2.x
+senaite.impress = git https://github.com/senaite/senaite.impress.git pushurl=git@github.com:senaite/senaite.impress.git branch=2.x
+senaite.jsonapi = git https://github.com/senaite/senaite.jsonapi.git pushurl=git@github.com:senaite/senaite.jsonapi.git branch=2.x
+senaite.lims = git https://github.com/senaite/senaite.lims.git pushurl=git@github.com:senaite/senaite.lims.git branch=2.x
 
 [instance]
 recipe = plone.recipe.zope2instance

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,8 @@ Changelog
 1.1.0 (unreleased)
 ------------------
 
+- #7  Fix default antibiotics are not created on install
+
 
 1.0.0 (2022-06-17)
 ------------------

--- a/src/senaite/abx/setuphandlers.py
+++ b/src/senaite/abx/setuphandlers.py
@@ -51,7 +51,7 @@ def setup_handler(context):
 
     # Setup initial data
     setup_antibiotic_classes(portal)
-    #setup_antibiotics(portal)
+    setup_antibiotics(portal)
 
     logger.info("{} setup handler [DONE]".format(PRODUCT_NAME.upper()))
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures default antibiotics are created on install

Related issue: https://github.com/senaite/senaite.abx/issues/5

## Current behavior before PR

Default antibiotics are not created on install

## Desired behavior after PR is merged

Default antibiotics are created on install

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html