### PR TITLE
Do not allow antibiotics with same title and/or abbreviation

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,8 @@ Changelog
 1.2.0 (unreleased)
 ------------------
 
-- #9 Remove IAntibioticBehavior and make Antibiotic folderish
+- #10 Do not allow antibiotics with same title and/or abbreviation
+-  #9 Remove IAntibioticBehavior and make Antibiotic folderish
 
 
 1.1.0 (2023-03-27)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

**Merge #9 first**

This Pull Request guarantees uniqueness of antibiotic names and abbreviations

Linked issue: https://github.com/senaite/senaite.abx/issues/

## Current behavior before PR

User can create (or edit) antibiotics with existing names and abbreviations

## Desired behavior after PR is merged

User is prompted to change the title or abbreviation of the antibiotic if already exists on edit/creation

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
