### PR TITLE
Fix TypeError on install

### DIFF
--- a/src/senaite/abx/profiles/default/types/Antibiotic.xml
+++ b/src/senaite/abx/profiles/default/types/Antibiotic.xml
@@ -43,7 +43,7 @@
   <property name="add_permission">cmf.AddPortalContent</property>
 
   <!-- Python class for content items of this sort -->
-  <property name="schema">senaite.abx.content.antibiotic.IAntibiotic</property>
+  <property name="schema">senaite.abx.content.antibiotic.IAntibioticSchema</property>
   <property name="klass">senaite.abx.content.antibiotic.Antibiotic</property>
 
   <!-- Dexterity behaviours for this type -->


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This fixes the following traceback that arises when installing the add-on for the first time, an issue that was introduced with #9

## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module Products.CMFPlone.controlpanel.browser.quickinstaller, line 689, in __call__
  Module Products.CMFPlone.controlpanel.browser.quickinstaller, line 454, in install_product
  Module Products.GenericSetup.tool, line 405, in runAllImportStepsFromProfile
   - __traceback_info__: profile-png.lims:default
  Module Products.GenericSetup.tool, line 1511, in _runImportStepsFromContext
  Module Products.GenericSetup.tool, line 1323, in _doRunImportStep
   - __traceback_info__: senaite.abx.setup_handler
  Module senaite.abx.setuphandlers, line 54, in setup_handler
  Module senaite.abx.setuphandlers, line 159, in setup_antibiotics
  Module senaite.abx.content.antibiotic, line 169, in setAntibioticClass
TypeError: 'NoneType' object is not callable
```

## Desired behavior after PR is merged

`senaite.abx` is installed without error

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
